### PR TITLE
Implicitly log halted events when debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,6 @@
 
 [Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v3.2.0-pre0...v3.2.0.pre1)
 
-**Fixed bugs:**
-
-- Add guard to morph that checks stimulusReflex [\#191](https://github.com/hopsoft/stimulus_reflex/pull/191) ([hopsoft](https://github.com/hopsoft))
-
 ## [v3.2.0-pre0](https://github.com/hopsoft/stimulus_reflex/tree/v3.2.0-pre0) (2020-05-07)
 
 [Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v3.2.0.pre0...v3.2.0-pre0)
@@ -52,6 +48,7 @@
 
 **Fixed bugs:**
 
+- Add guard to morph that checks stimulusReflex [\#191](https://github.com/hopsoft/stimulus_reflex/pull/191) ([hopsoft](https://github.com/hopsoft))
 -  Pluralize the generated class name, so that will match with the file name [\#178](https://github.com/hopsoft/stimulus_reflex/pull/178) ([darkrubyist](https://github.com/darkrubyist))
 
 **Closed issues:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,6 @@
 
 [Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v3.2.0-pre0...v3.2.0.pre1)
 
-**Fixed bugs:**
-
-- Add guard to morph that checks stimulusReflex [\#191](https://github.com/hopsoft/stimulus_reflex/pull/191) ([hopsoft](https://github.com/hopsoft))
-
 ## [v3.2.0-pre0](https://github.com/hopsoft/stimulus_reflex/tree/v3.2.0-pre0) (2020-05-07)
 
 [Full Changelog](https://github.com/hopsoft/stimulus_reflex/compare/v3.2.0.pre0...v3.2.0-pre0)
@@ -40,6 +36,7 @@
 
 **Fixed bugs:**
 
+- Add guard to morph that checks stimulusReflex [\#191](https://github.com/hopsoft/stimulus_reflex/pull/191) ([hopsoft](https://github.com/hopsoft))
 -  Pluralize the generated class name, so that will match with the file name [\#178](https://github.com/hopsoft/stimulus_reflex/pull/178) ([darkrubyist](https://github.com/darkrubyist))
 
 **Closed issues:**

--- a/javascript/lifecycle.js
+++ b/javascript/lifecycle.js
@@ -6,6 +6,7 @@ import { camelize } from './utils'
 //   * before
 //   * success
 //   * error
+//   * halted
 //   * after
 //
 // - element - the element that triggered the reflex (not necessarily the Stimulus controller's element)
@@ -81,6 +82,12 @@ document.addEventListener(
 )
 
 document.addEventListener(
+  'stimulus-reflex:halted',
+  event => invokeLifecycleMethod('halted', event.target),
+  true
+)
+
+document.addEventListener(
   'stimulus-reflex:after',
   event => invokeLifecycleMethod('after', event.target),
   true
@@ -92,6 +99,7 @@ document.addEventListener(
 //   * before
 //   * success
 //   * error
+//   * halted
 //   * after
 //
 // - element - the element that triggered the reflex (not necessarily the Stimulus controller's element)

--- a/javascript/log.js
+++ b/javascript/log.js
@@ -16,7 +16,7 @@ function request (
   })
 }
 
-function success (response) {
+function success (response, options = { halted: false }) {
   const html = {}
   const payloads = {}
   const elements = {}
@@ -32,6 +32,7 @@ function success (response) {
   console.log(`\u2B05 ${target}`, {
     reflexId,
     duration: `${new Date() - logs[reflexId]}ms`,
+    halted: options.halted,
     elements,
     payloads,
     html

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -186,7 +186,7 @@ class StimulusReflexController extends Controller {
 }
 
 // Sets up declarative reflex behavior.
-// Any elements that define data-reflex will automatcially be wired up with the default StimulusReflexController.
+// Any elements that define data-reflex will automatically be wired up with the default StimulusReflexController.
 //
 const setupDeclarativeReflexes = () => {
   document
@@ -331,7 +331,7 @@ if (!document.stimulusReflexInitialized) {
 
     if (element && subject == 'error') element.reflexError = body
 
-    let response = {
+    const response = {
       data: promise && promise.data,
       element,
       event,

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -345,6 +345,25 @@ if (!document.stimulusReflexInitialized) {
     dispatchLifecycleEvent('error', element)
     if (debugging) Log.error(response)
   })
+  document.addEventListener('stimulus-reflex:abort', event => {
+    const { reflexId, attrs } = event.detail.stimulusReflex || {}
+    const element = findElement(attrs)
+    const promise = promises[reflexId]
+
+    const response = {
+      data: promise && promise.data,
+      element,
+      event
+    }
+
+    if (promise) {
+      delete promises[reflexId]
+      promise.resolve(response)
+    }
+
+    dispatchLifecycleEvent('halted', element)
+    if (debugging) Log.success(response)
+  })
 }
 
 export default {

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -328,6 +328,10 @@ if (!document.stimulusReflexInitialized) {
     const { subject, body } = serverMessage
     const element = findElement(attrs)
     const promise = promises[reflexId]
+    const subjects = {
+      error: true,
+      halted: true
+    }
 
     if (element && subject == 'error') element.reflexError = body
 
@@ -349,13 +353,20 @@ if (!document.stimulusReflexInitialized) {
       }
     }
 
-    if (element && ['error', 'halted'].includes(subject))
-      dispatchLifecycleEvent(subject, element)
+    if (element && subjects[subject]) dispatchLifecycleEvent(subject, element)
 
-    if (debugging && subject == 'error') {
-      Log.error(response)
-    } else if (debugging) {
-      Log.success(response)
+    if (debugging) {
+      switch (subject) {
+        case 'error':
+          Log.error(response)
+          break
+        case 'halted':
+          Log.success(response, { halted: true })
+          break
+        default:
+          Log.success(response)
+          break
+      }
     }
   })
 }


### PR DESCRIPTION
Minor refactor to implicitly log halted events when `debug == true`.